### PR TITLE
#50 一覧ページ 問題点の修正

### DIFF
--- a/src/app/blogs/BlogCard.tsx
+++ b/src/app/blogs/BlogCard.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
-import type { Blog } from "@/lib/actions/blogs/getBlogs";
+import type { Blog } from "@/types/blog";
 
 type Props = {
   blog: Blog;
@@ -40,7 +40,7 @@ export default function BlogCard({ blog }: Props) {
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4 text-sm text-slate-500">
               <span>{blog.user.name}</span>
-              <span>{blog.createdAt.toLocaleDateString('ja-JP')}</span>
+              <span>{new Date(blog.createdAt).toLocaleDateString('ja-JP')}</span>
             </div>
             {blog.tags.length > 0 && (
               <div className="flex gap-2">

--- a/src/app/blogs/BlogList.tsx
+++ b/src/app/blogs/BlogList.tsx
@@ -1,0 +1,31 @@
+import { getBlogs } from '@/lib/actions/blogs/getBlogs';
+import BlogCard from './BlogCard';
+import Pagination from './Pagination';
+
+type Props = {
+  isAdmin: boolean;
+  page: number;
+};
+
+export default async function BlogList({ isAdmin, page }: Props) {
+  const { blogs, totalPages } = await getBlogs({ isAdmin, page });
+
+  if (blogs.length === 0) {
+    return (
+      <div className="rounded-lg border border-slate-200 bg-white p-8 text-center">
+        <p className="text-slate-600">記事がありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-6">
+        {blogs.map((blog) => (
+          <BlogCard key={blog.id} blog={blog} />
+        ))}
+      </div>
+      {totalPages > 1 && <Pagination currentPage={page} totalPages={totalPages} />}
+    </div>
+  );
+}

--- a/src/app/blogs/BlogListSkeleton.tsx
+++ b/src/app/blogs/BlogListSkeleton.tsx
@@ -1,0 +1,9 @@
+export default function BlogListSkeleton() {
+  return (
+    <div className="grid gap-6">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="h-24 animate-pulse rounded-lg bg-slate-200" />
+      ))}
+    </div>
+  );
+}

--- a/src/app/blogs/Pagination.tsx
+++ b/src/app/blogs/Pagination.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+
+type Props = {
+  currentPage: number;
+  totalPages: number;
+};
+
+export default function Pagination({ currentPage, totalPages }: Props) {
+  return (
+    <div className="flex items-center justify-center gap-3 pt-4">
+      {currentPage > 1 ? (
+        <Link
+          href={`/blogs?page=${currentPage - 1}`}
+          className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+        >
+          前へ
+        </Link>
+      ) : (
+        <span className="rounded-md border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-400">
+          前へ
+        </span>
+      )}
+      <span className="text-sm text-slate-600">
+        {currentPage} / {totalPages}
+      </span>
+      {currentPage < totalPages ? (
+        <Link
+          href={`/blogs?page=${currentPage + 1}`}
+          className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+        >
+          次へ
+        </Link>
+      ) : (
+        <span className="rounded-md border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-400">
+          次へ
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -1,8 +1,23 @@
-import { getBlogs } from "@/lib/actions/blogs/getBlogs";
-import BlogCard from "./BlogCard";
+import { Suspense } from 'react';
+import { auth } from '@/auth';
+import BlogList from './BlogList';
+import BlogListSkeleton from './BlogListSkeleton';
+import type { Metadata } from 'next';
 
-export default async function BlogPages() {
-  const blogs = await getBlogs();
+export const metadata: Metadata = {
+  title: 'ブログ一覧 | Tech Blog',
+  description: '開発で得た知識や実装メモを掲載しています',
+};
+
+type Props = {
+  searchParams: Promise<{ page?: string }>;
+};
+
+export default async function BlogPages({ searchParams }: Props) {
+  const { page: pageParam } = await searchParams;
+  const page = Math.max(1, parseInt(pageParam ?? '1', 10) || 1);
+  const session = await auth();
+  const isAdmin = session?.user?.role === 'ADMIN';
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 to-white">
@@ -11,18 +26,9 @@ export default async function BlogPages() {
           <h1 className="text-3xl font-semibold text-slate-900">ブログ一覧</h1>
           <p className="mt-2 text-slate-600">全ブログ記事を閲覧できます</p>
         </div>
-
-        {blogs.length === 0 ? (
-          <div className="rounded-lg border border-slate-200 bg-white p-8 text-center">
-            <p className="text-slate-600">記事がありません</p>
-          </div>
-        ) : (
-          <div className="grid gap-6">
-            {blogs.map((blog) => (
-              <BlogCard key={blog.id} blog={blog} />
-            ))}
-          </div>
-        )}
+        <Suspense fallback={<BlogListSkeleton />}>
+          <BlogList isAdmin={isAdmin} page={page} />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/lib/actions/blogs/getBlogs.ts
+++ b/src/lib/actions/blogs/getBlogs.ts
@@ -1,45 +1,53 @@
-'use server';
-
 import { prisma } from '@/lib/prisma';
-import { auth } from '@/auth';
+import { unstable_cache } from 'next/cache';
+import type { GetBlogsResult } from '@/types/blog';
 
-export type Blog = {
-  id: number;
-  title: string;
-  context: string;
-  isPublic: boolean;
-  createdAt: Date;
-  user: {
-    name: string;
-  };
-  tags: Array<{
-    name: string;
-    imagePath?: string | null;
-  }>;
+export const PAGE_SIZE = 10;
+
+type GetBlogsParams = {
+  isAdmin: boolean;
+  page: number;
 };
 
-export async function getBlogs(): Promise<Blog[]> {
-  const session = await auth();
-  const isAdmin = session?.user?.role === 'ADMIN';
+async function getBlogs({ isAdmin, page }: GetBlogsParams): Promise<GetBlogsResult> {
+  const where = isAdmin ? {} : { isPublic: true };
 
-  return prisma.context.findMany({
-    where: isAdmin ? {} : { isPublic: true },
-    select: {
-      id: true,
-      title: true,
-      context: true,
-      isPublic: true,
-      createdAt: true,
-      user: {
-        select: { name: true },
-      },
-      tags: {
-        select: {
-          name: true,
-          imagePath: true,
+  const [blogs, total] = await Promise.all([
+    prisma.context.findMany({
+      where,
+      select: {
+        id: true,
+        title: true,
+        context: true,
+        isPublic: true,
+        createdAt: true,
+        user: {
+          select: { name: true },
+        },
+        tags: {
+          select: {
+            name: true,
+            imagePath: true,
+          },
         },
       },
-    },
-    orderBy: { createdAt: 'desc' },
-  });
+      orderBy: { createdAt: 'desc' },
+      take: PAGE_SIZE,
+      skip: (page - 1) * PAGE_SIZE,
+    }),
+    prisma.context.count({ where }),
+  ]);
+
+  return {
+    blogs: blogs.map((blog) => ({ ...blog, createdAt: blog.createdAt.toISOString() })),
+    total,
+    totalPages: Math.ceil(total / PAGE_SIZE),
+  };
 }
+
+const cachedGetBlogs = unstable_cache(getBlogs, ['blogs-list'], {
+  revalidate: 60,
+  tags: ['blogs'],
+});
+
+export { cachedGetBlogs as getBlogs };

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,3 +1,24 @@
+export type Blog = {
+  id: number;
+  title: string;
+  context: string;
+  isPublic: boolean;
+  createdAt: string;
+  user: {
+    name: string;
+  };
+  tags: Array<{
+    name: string;
+    imagePath?: string | null;
+  }>;
+};
+
+export type GetBlogsResult = {
+  blogs: Blog[];
+  total: number;
+  totalPages: number;
+};
+
 export type BlogDetail = {
   id: number;
   title: string;


### PR DESCRIPTION
  src/app/blogs/page.tsx
  - Suspense + BlogList / BlogListSkeleton に置き換え → 100行超えのためコンポーネント分割
  - searchParams でページネーション対応を追加 → ページ切り替え機能の実装
  - auth() で管理者判定を追加 → 管理者は非公開記事も表示するため
  - metadata を追加 → SEO対応

  src/app/blogs/BlogList.tsx（新規）
  - page.tsx から分割 → 単一責任の原則に基づきデータ取得・一覧表示を独立したコンポーネントに

  src/app/blogs/BlogListSkeleton.tsx（新規）
  - page.tsx から分割 → Suspense の fallback 用スケルトンを独立したコンポーネントに

  src/app/blogs/Pagination.tsx（新規）
  - page.tsx から分割 → ページネーション UI を独立したコンポーネントに

  src/app/blogs/BlogCard.tsx
  - Blog 型のインポート元を @/types/blog に変更 → 型定義を types/ に一元管理するため
  - blog.createdAt を new Date(blog.createdAt).toLocaleDateString() に変更 → unstable_cache が JSON シリアライズするため createdAt が string で届くため

  src/lib/actions/blogs/getBlogs.ts
  - 'use server' 削除・unstable_cache 追加 → Server Action からキャッシュ付きデータ取得関数に変更
  - auth() を削除し isAdmin を引数で受け取るよう変更 → 呼び出し元（page.tsx）で認証処理を担うため
  - ページネーション対応（take / skip）を追加 → ページ切り替え機能の実装
  - Blog / GetBlogsResult 型を削除 → @/types/blog に移動
  - createdAt.toISOString() で文字列変換 → unstable_cache の JSON シリアライズに型を合わせるため
  - 内部関数名を fetchBlogs → getBlogs に変更 → fetch APIではなく Prisma で取得しているため

  src/types/blog.ts
  - Blog / GetBlogsResult 型を追加 → 型定義を getBlogs.ts から types/ に一元管理するため
  - Blog.createdAt を Date → string に変更 → unstable_cache の JSON シリアライズ後の実態に合わせるため