### PR TITLE
#52 ブログ詳細ページの問題点の修正

### DIFF
--- a/src/app/blogs/[id]/page.tsx
+++ b/src/app/blogs/[id]/page.tsx
@@ -4,9 +4,8 @@ import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import { auth } from '@/auth';
-import { prisma } from '@/lib/prisma';
+import { getBlog } from '@/lib/actions/blogs/getBlog';
 import BlogActions from './BlogActions';
-import type { BlogDetail } from '@/types/blog';
 
 type BlogDetailPageProps = {
   params: Promise<{ id: string }>;
@@ -17,23 +16,7 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
   const session = await auth();
   const isAdmin = session?.user?.role === 'ADMIN';
 
-  const blog: BlogDetail | null = await prisma.context.findUnique({
-    where: { id: parseInt(id) },
-    select: {
-      id: true,
-      title: true,
-      context: true,
-      isPublic: true,
-      createdAt: true,
-      updatedAt: true,
-      user: {
-        select: { id: true, name: true },
-      },
-      tags: {
-        select: { name: true },
-      },
-    },
-  });
+  const blog = await getBlog(parseInt(id));
 
   if (!blog || (!blog.isPublic && !isAdmin)) {
     notFound();
@@ -53,9 +36,9 @@ export default async function BlogDetailPage({ params }: BlogDetailPageProps) {
                 <h1 className="text-3xl font-bold text-slate-900">{blog.title}</h1>
                 <div className="mt-4 flex items-center gap-6 text-sm text-slate-600">
                   <span>{blog.user.name}</span>
-                  <span>公開日: {blog.createdAt.toLocaleDateString('ja-JP')}</span>
-                  {blog.createdAt.getTime() !== blog.updatedAt.getTime() && (
-                    <span>更新日: {blog.updatedAt.toLocaleDateString('ja-JP')}</span>
+                  <span>公開日: {new Date(blog.createdAt).toLocaleDateString('ja-JP')}</span>
+                  {blog.createdAt !== blog.updatedAt && (
+                    <span>更新日: {new Date(blog.updatedAt).toLocaleDateString('ja-JP')}</span>
                   )}
                 </div>
               </div>

--- a/src/lib/actions/blogs/getBlog.ts
+++ b/src/lib/actions/blogs/getBlog.ts
@@ -1,0 +1,38 @@
+import { prisma } from '@/lib/prisma';
+import { unstable_cache } from 'next/cache';
+import type { BlogDetail } from '@/types/blog';
+
+async function getBlog(id: number): Promise<BlogDetail | null> {
+  const blog = await prisma.context.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      title: true,
+      context: true,
+      isPublic: true,
+      createdAt: true,
+      updatedAt: true,
+      user: {
+        select: { id: true, name: true },
+      },
+      tags: {
+        select: { name: true },
+      },
+    },
+  });
+
+  if (!blog) return null;
+
+  return {
+    ...blog,
+    createdAt: blog.createdAt.toISOString(),
+    updatedAt: blog.updatedAt.toISOString(),
+  };
+}
+
+const cachedGetBlog = unstable_cache(getBlog, ['blog-detail'], {
+  revalidate: 60,
+  tags: ['blogs'],
+});
+
+export { cachedGetBlog as getBlog };

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -24,8 +24,8 @@ export type BlogDetail = {
   title: string;
   context: string;
   isPublic: boolean;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: string;
+  updatedAt: string;
   user: {
     id: string;
     name: string;


### PR DESCRIPTION
  src/types/blog.ts
  - BlogDetail.createdAt / updatedAt を Date → string に変更

  src/lib/actions/blogs/getBlog.ts（新規）
  - データ取得処理を page.tsx から切り出し
  - unstable_cache でキャッシュを追加
  - createdAt / updatedAt を toISOString() で変換

  src/app/blogs/[id]/page.tsx
  - prisma 直接呼び出しを削除し getBlog に置き換え
  - .getTime() 比較を文字列比較（!==）に変更
  - .toLocaleDateString() を new Date() でラップ