### PR TITLE
#58 認証処理問題点の修正

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,8 +1,7 @@
 import NextAuth from "next-auth"
 import { authConfig } from '@/auth.config';
 import Credentials from "next-auth/providers/credentials"
-import type { SignIn } from "@/interface/signIn";
-import { ERROR_TYPES } from '@/constants/errorTypes';
+import { checkEmailPassword } from '@/validations/user';
 import { CustomCredentialsSignin } from '@/class/CustomCredentialsSignin';
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
@@ -10,47 +9,19 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
   providers: [
     Credentials({
       authorize: async (credentials) => {
-        try {
-          // ユーザー認証のロジックをここに実装
-          const res = await fetch(`${process.env.URL}/api/auth/signIn`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ 
-              email: credentials?.email,
-              password: credentials?.password
-            }),
-          })
+        const result = await checkEmailPassword(
+          credentials?.email as string,
+          credentials?.password as string,
+        );
 
-          // レスポンスが正常でなければエラーを投げる
-          if (!res.ok) {
-            const data:SignIn = await res.json();
-            if (data.error_type === ERROR_TYPES.NOT_EXISTS_USER_ERROR) {
-              throw new CustomCredentialsSignin("パスワードまたはメールアドレスが間違っています。");
-            }
-            throw new Error("サーバーエラーが発生しました。時間をおいて再試行してください。");
-          }
-
-          const data:SignIn = await res.json();
-
-          // ユーザー情報を抽出
-          const user = {
-            id: data.id ?? undefined,
-            role: data.role ?? 'USER',
-          };
-
-          if (!data.id) {
-            throw new Error("サーバーエラーが発生しました。時間をおいて再試行してください。");
-          }
-
-          return user;
-        } catch (error) {
-          // CustomCredentialsSigninはそのまま投げる
-          if (error instanceof CustomCredentialsSignin) {
-            throw error;
-          }
-          // その他のエラーは一般的な認証エラーとして投げる
-          throw error;
+        if (!result.success || !result.id) {
+          throw new CustomCredentialsSignin("パスワードまたはメールアドレスが間違っています。");
         }
+
+        return {
+          id: result.id ?? undefined,
+          role: result.role ?? 'USER',
+        };
       },
     })
   ],

--- a/src/lib/actions/signIn.ts
+++ b/src/lib/actions/signIn.ts
@@ -1,7 +1,8 @@
 'use server'
 
-import {signInSchema } from '@/validations/signIn';
-import { signIn } from '@/auth'; // signIn関数のインポート
+import { isRedirectError } from 'next/dist/client/components/redirect-error';
+import { signInSchema } from '@/validations/signIn';
+import { signIn } from '@/auth';
 import { handleAuthError } from './error';
 
 type ActionState = {
@@ -43,15 +44,13 @@ export async function submitSignInForm(
   }
 
   try {
-    // サインイン処理
     await signIn('credentials', {
       email: formData.get('email') as string,
       password: formData.get('password') as string,
-      redirect: false,
+      redirectTo: '/',
     });
-
-    return { success: true };
   } catch (error) {
+    if (isRedirectError(error)) throw error;
     return handleAuthError(error, {
       email: email as string,
     });


### PR DESCRIPTION
  auth.ts

  - API Route 経由の認証を廃止 — fetch(/api/auth/signIn) による HTTP リクエストを削除し、checkEmailPassword を直接呼び出すように変更
  - 不要な依存を削除 — SignIn 型、ERROR_TYPES 定数が不要に
  - try-catch の簡素化 — API レスポンスのハンドリングが不要になり、認証ロジックがシンプルに

  signIn.ts

  - redirect: false → redirectTo: '/' — サーバー側リダイレクトに変更
  - isRedirectError の追加 — redirect() が投げる特殊エラーを再スローしてリダイレクトを正しく動作させる
  - return { success: true } の削除 — リダイレクトするため成功時の戻り値が不要に