### PR TITLE
バリデーションスキーマ(src/validations/配下)にテストを追加

### DIFF
--- a/__tests__/validations/blogs/upsert.test.ts
+++ b/__tests__/validations/blogs/upsert.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { createBlogSchema } from '@/validations/blogs/upsert';
+
+describe('createBlogSchema', () => {
+  describe('正常系のテスト', () => {
+    it('妥当な値の場合、パースに成功する', () => {
+      const result = createBlogSchema.safeParse({
+        title: 'タイトル',
+        context: '本文',
+        tags: ['tag1'],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('タイトルが境界値（100文字）の場合、パースに成功する', () => {
+      const result = createBlogSchema.safeParse({
+        title: 'a'.repeat(100),
+        context: '本文',
+        tags: ['tag1'],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('タグが複数の場合、パースに成功する', () => {
+      const result = createBlogSchema.safeParse({
+        title: 'タイトル',
+        context: '本文',
+        tags: ['tag1', 'tag2', 'tag3'],
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('異常系のテスト', () => {
+    it('タイトルが空文字の場合、必須エラーメッセージを返す', () => {
+      const result = createBlogSchema.safeParse({
+        title: '',
+        context: '本文',
+        tags: ['tag1'],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.title).toEqual(['タイトルは必須です。']);
+      }
+    });
+
+    it('タイトルが境界値超（101文字）の場合、文字数エラーメッセージを返す', () => {
+      const result = createBlogSchema.safeParse({
+        title: 'a'.repeat(101),
+        context: '本文',
+        tags: ['tag1'],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.title).toEqual([
+          'タイトルは100文字以内である必要があります。',
+        ]);
+      }
+    });
+
+    it('コンテキストが空文字の場合、必須エラーメッセージを返す', () => {
+      const result = createBlogSchema.safeParse({
+        title: 'タイトル',
+        context: '',
+        tags: ['tag1'],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.context).toEqual(['コンテキストは必須です。']);
+      }
+    });
+
+    it('タグが空配列の場合、必須エラーメッセージを返す', () => {
+      const result = createBlogSchema.safeParse({
+        title: 'タイトル',
+        context: '本文',
+        tags: [],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.tags).toEqual([
+          '少なくとも1つのタグを選択してください。',
+        ]);
+      }
+    });
+  });
+});

--- a/__tests__/validations/signIn.test.ts
+++ b/__tests__/validations/signIn.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { signInSchema } from '@/validations/signIn';
+
+describe('signInSchema', () => {
+  describe('正常系のテスト', () => {
+    it('妥当な値の場合、パースに成功する', () => {
+      const result = signInSchema.safeParse({
+        email: 'test@example.com',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('パスワードが境界値（6文字）の場合、パースに成功する', () => {
+      const result = signInSchema.safeParse({
+        email: 'test@example.com',
+        password: '123456',
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('異常系のテスト', () => {
+    it('メールアドレスが空文字の場合、必須エラーメッセージを返す', () => {
+      const result = signInSchema.safeParse({
+        email: '',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.email).toEqual([
+          'メールアドレスは必須です。',
+          '有効なメールアドレスを入力してください。',
+        ]);
+      }
+    });
+
+    it('メールアドレスの形式が不正な場合、フォーマットエラーメッセージを返す', () => {
+      const result = signInSchema.safeParse({
+        email: 'invalid-email',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.email).toEqual([
+          '有効なメールアドレスを入力してください。',
+        ]);
+      }
+    });
+
+    it('パスワードが空文字の場合、文字数エラーメッセージを返す', () => {
+      const result = signInSchema.safeParse({
+        email: 'test@example.com',
+        password: '',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.password).toEqual([
+          'パスワードは6文字以上である必要があります。',
+        ]);
+      }
+    });
+
+    it('パスワードが境界値未満（5文字）の場合、文字数エラーメッセージを返す', () => {
+      const result = signInSchema.safeParse({
+        email: 'test@example.com',
+        password: '12345',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.password).toEqual([
+          'パスワードは6文字以上である必要があります。',
+        ]);
+      }
+    });
+  });
+});

--- a/__tests__/validations/signUp.test.ts
+++ b/__tests__/validations/signUp.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { signUpSchema } from '@/validations/signUp';
+
+describe('signUpSchema', () => {
+  describe('正常系のテスト', () => {
+    it('妥当な値の場合、パースに成功する', () => {
+      const result = signUpSchema.safeParse({
+        name: 'テストユーザー',
+        email: 'test@example.com',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('名前が境界値（30文字）の場合、パースに成功する', () => {
+      const result = signUpSchema.safeParse({
+        name: 'あ'.repeat(30),
+        email: 'test@example.com',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('パスワードが境界値（6文字）の場合、パースに成功する', () => {
+      const result = signUpSchema.safeParse({
+        name: 'テストユーザー',
+        email: 'test@example.com',
+        password: '123456',
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('異常系のテスト', () => {
+    it('名前が空文字の場合、必須エラーメッセージを返す', () => {
+      const result = signUpSchema.safeParse({
+        name: '',
+        email: 'test@example.com',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.name).toEqual(['名前は必須です。']);
+      }
+    });
+
+    it('名前が境界値超（31文字）の場合、文字数エラーメッセージを返す', () => {
+      const result = signUpSchema.safeParse({
+        name: 'あ'.repeat(31),
+        email: 'test@example.com',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.name).toEqual([
+          '名前は30文字以内である必要があります。',
+        ]);
+      }
+    });
+
+    it('メールアドレスが空文字の場合、必須エラーメッセージを返す', () => {
+      const result = signUpSchema.safeParse({
+        name: 'テストユーザー',
+        email: '',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.email).toEqual([
+          'メールアドレスは必須です。',
+          '有効なメールアドレスを入力してください。',
+        ]);
+      }
+    });
+
+    it('メールアドレスの形式が不正な場合、フォーマットエラーメッセージを返す', () => {
+      const result = signUpSchema.safeParse({
+        name: 'テストユーザー',
+        email: 'invalid-email',
+        password: 'password123',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.email).toEqual([
+          '有効なメールアドレスを入力してください。',
+        ]);
+      }
+    });
+
+    it('パスワードが空文字の場合、文字数エラーメッセージを返す', () => {
+      const result = signUpSchema.safeParse({
+        name: 'テストユーザー',
+        email: 'test@example.com',
+        password: '',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.password).toEqual([
+          'パスワードは6文字以上である必要があります。',
+        ]);
+      }
+    });
+
+    it('パスワードが境界値未満（5文字）の場合、文字数エラーメッセージを返す', () => {
+      const result = signUpSchema.safeParse({
+        name: 'テストユーザー',
+        email: 'test@example.com',
+        password: '12345',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.password).toEqual([
+          'パスワードは6文字以上である必要があります。',
+        ]);
+      }
+    });
+  });
+});

--- a/__tests__/validations/tags/upsert.test.ts
+++ b/__tests__/validations/tags/upsert.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { upsertTagSchema } from '@/validations/tags/upsert';
+
+describe('upsertTagSchema', () => {
+  describe('正常系のテスト', () => {
+    it('妥当な値の場合、パースに成功する', () => {
+      const result = upsertTagSchema.safeParse({ name: 'React' });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('タグ名が境界値（50文字）の場合、パースに成功する', () => {
+      const result = upsertTagSchema.safeParse({ name: 'a'.repeat(50) });
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('異常系のテスト', () => {
+    it('タグ名が空文字の場合、必須エラーメッセージを返す', () => {
+      const result = upsertTagSchema.safeParse({ name: '' });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.name).toEqual(['タグ名を入力してください']);
+      }
+    });
+
+    it('タグ名が境界値超（51文字）の場合、文字数エラーメッセージを返す', () => {
+      const result = upsertTagSchema.safeParse({ name: 'a'.repeat(51) });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.name).toEqual([
+          'タグ名は50文字以内である必要があります',
+        ]);
+      }
+    });
+  });
+});

--- a/__tests__/validations/user.test.ts
+++ b/__tests__/validations/user.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { existCheck, checkEmailPassword, hashPassword } from '@/validations/user';
+import { prisma } from '@/lib/prisma';
+import bcrypt from 'bcrypt';
+
+// user.ts はZodスキーマではなく、DB(Prisma)・bcryptに依存する認証関連の関数群のため、
+// 他のバリデーションスキーマと異なりモックを用いてテストする。
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+  },
+}));
+
+vi.mock('bcrypt', () => ({
+  default: {
+    genSaltSync: vi.fn(() => 'salt'),
+    hashSync: vi.fn(() => 'hashed-password'),
+    compareSync: vi.fn(),
+  },
+}));
+
+describe('existCheck', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('正常系のテスト', () => {
+    it('未登録のメールアドレスの場合、登録可能を返す', async () => {
+      (prisma.user.findUnique as Mock).mockResolvedValue(null);
+
+      const result = await existCheck('new@example.com');
+
+      expect(result).toEqual({
+        success: true,
+        message: 'このメールアドレスは登録可能です。',
+        id: '',
+      });
+    });
+  });
+
+  describe('異常系のテスト', () => {
+    it('登録済みのメールアドレスの場合、エラーを返す', async () => {
+      (prisma.user.findUnique as Mock).mockResolvedValue({ id: 'user-1' });
+
+      const result = await existCheck('exist@example.com');
+
+      expect(result).toEqual({
+        success: false,
+        message: 'このメールアドレスは既に登録されています。',
+        id: 'user-1',
+      });
+    });
+
+    it('DBエラーが発生した場合、汎用エラーメッセージを返す', async () => {
+      (prisma.user.findUnique as Mock).mockRejectedValue(new Error('DB接続エラー'));
+
+      const result = await existCheck('error@example.com');
+
+      expect(result).toEqual({
+        success: false,
+        message: 'エラーが発生しました。管理者に連絡してください。',
+        id: '',
+      });
+    });
+  });
+});
+
+describe('checkEmailPassword', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('正常系のテスト', () => {
+    it('メールアドレスとパスワードが一致する場合、ユーザー情報を返す', async () => {
+      (prisma.user.findUnique as Mock).mockResolvedValue({
+        id: 'user-1',
+        password: 'hashed-password',
+        role: 'USER',
+      });
+      (bcrypt.compareSync as Mock).mockReturnValue(true);
+
+      const result = await checkEmailPassword('test@example.com', 'password123');
+
+      expect(result).toEqual({
+        success: true,
+        message: 'メールアドレスまたはパスワードが一致しました。',
+        id: 'user-1',
+        role: 'USER',
+      });
+    });
+  });
+
+  describe('異常系のテスト', () => {
+    it('ユーザーが存在しない場合、エラーを返す', async () => {
+      (prisma.user.findUnique as Mock).mockResolvedValue(null);
+
+      const result = await checkEmailPassword('notfound@example.com', 'password123');
+
+      expect(result).toEqual({
+        success: false,
+        message: 'メールアドレスまたはパスワードが間違っています。',
+        id: null,
+        role: null,
+      });
+    });
+
+    it('パスワードが一致しない場合、エラーを返す', async () => {
+      (prisma.user.findUnique as Mock).mockResolvedValue({
+        id: 'user-1',
+        password: 'hashed-password',
+        role: 'USER',
+      });
+      (bcrypt.compareSync as Mock).mockReturnValue(false);
+
+      const result = await checkEmailPassword('test@example.com', 'wrong-password');
+
+      expect(result).toEqual({
+        success: false,
+        message: 'メールアドレスまたはパスワードが間違っています。',
+        id: null,
+        role: null,
+      });
+    });
+  });
+});
+
+describe('hashPassword', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('正常系のテスト', () => {
+    it('パスワードをハッシュ化した文字列を返す', async () => {
+      (bcrypt.genSaltSync as Mock).mockReturnValue('salt');
+      (bcrypt.hashSync as Mock).mockReturnValue('hashed-password');
+
+      const result = await hashPassword('password123');
+
+      expect(result).toBe('hashed-password');
+      expect(bcrypt.hashSync).toHaveBeenCalledWith('password123', 'salt');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `src/validations/signIn.ts` / `signUp.ts` / `tags/upsert.ts` / `blogs/upsert.ts` の各Zodスキーマに `safeParse` を直接呼び出すテストを追加（正常系、必須項目の空文字エラー、文字数境界値）
- `src/validations/user.ts`（DB・bcryptに依存する認証関連関数群）は既存のServer Actionテストと同様に `prisma`/`bcrypt` をモックしてテストを追加

## Test plan
- [x] `npm run lint`(エラー0件、既存warningのみ)
- [x] `npm run test`(111件全てpass、うち新規33件)
- [x] `/code-review medium` を実施(指摘8件はいずれも今回変更した5ファイルには該当せず、development比較では対象外の既存コードの問題と判断)

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)