### PR TITLE
ユーティリティ関数(image.ts/markdown.ts)にテストを追加

### DIFF
--- a/__tests__/utils/image.test.ts
+++ b/__tests__/utils/image.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Mock } from 'vitest';
+import { mkdir, writeFile } from 'fs/promises';
+import { saveImage, saveImageToLocal } from '@/utils/image';
+import { supabase } from '@/lib/supabase';
+
+vi.mock('fs/promises', () => {
+  const mkdir = vi.fn();
+  const writeFile = vi.fn();
+  return { mkdir, writeFile, default: { mkdir, writeFile } };
+});
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    storage: {
+      from: vi.fn(),
+    },
+  },
+}));
+
+const createFile = (name = 'test.png', type = 'image/png') => {
+  const content = new Uint8Array([1, 2, 3]);
+  const file = new File([content], name, { type });
+  // jsdom の File/Blob には arrayBuffer() が実装されていないためテスト用に補う
+  Object.defineProperty(file, 'arrayBuffer', {
+    value: async () => content.buffer,
+  });
+  return file;
+};
+
+describe('saveImageToLocal', () => {
+  const originalCwd = process.cwd;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.cwd = vi.fn(() => '/app');
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+  });
+
+  afterEach(() => {
+    process.cwd = originalCwd;
+    vi.restoreAllMocks();
+  });
+
+  it('保存に成功した場合、公開URLパスを返す', async () => {
+    (mkdir as Mock).mockResolvedValue(undefined);
+    (writeFile as Mock).mockResolvedValue(undefined);
+    const file = createFile();
+
+    const result = await saveImageToLocal(file, 'blogs/temp');
+
+    expect(result).toBe('/blogs/temp/1700000000000_test.png');
+    expect(mkdir).toHaveBeenCalledWith('/app/public/blogs/temp', { recursive: true });
+    expect(writeFile).toHaveBeenCalledWith(
+      '/app/public/blogs/temp/1700000000000_test.png',
+      expect.any(Buffer)
+    );
+  });
+
+  it('ディレクトリ作成に失敗した場合、nullを返す', async () => {
+    (mkdir as Mock).mockRejectedValue(new Error('mkdir failed'));
+    const file = createFile();
+
+    const result = await saveImageToLocal(file, 'blogs/temp');
+
+    expect(result).toBeNull();
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('ファイル書き込みに失敗した場合、nullを返す', async () => {
+    (mkdir as Mock).mockResolvedValue(undefined);
+    (writeFile as Mock).mockRejectedValue(new Error('write failed'));
+    const file = createFile();
+
+    const result = await saveImageToLocal(file, 'blogs/temp');
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('saveImage', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_USE_SUPABASE_STORAGE;
+  const originalCwd = process.cwd;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.cwd = vi.fn(() => '/app');
+    vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+  });
+
+  afterEach(() => {
+    process.cwd = originalCwd;
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_USE_SUPABASE_STORAGE;
+    } else {
+      process.env.NEXT_PUBLIC_USE_SUPABASE_STORAGE = originalEnv;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('USE_SUPABASE_STORAGEがtrueでない場合、ローカル保存を行う', async () => {
+    delete process.env.NEXT_PUBLIC_USE_SUPABASE_STORAGE;
+    (mkdir as Mock).mockResolvedValue(undefined);
+    (writeFile as Mock).mockResolvedValue(undefined);
+    const file = createFile();
+
+    const result = await saveImage(file, 'blogs/temp');
+
+    expect(result).toBe('/blogs/temp/1700000000000_test.png');
+    expect(supabase.storage.from).not.toHaveBeenCalled();
+  });
+
+  it('USE_SUPABASE_STORAGEがtrueの場合、Supabaseへアップロードして公開URLを返す', async () => {
+    process.env.NEXT_PUBLIC_USE_SUPABASE_STORAGE = 'true';
+    const upload = vi.fn().mockResolvedValue({ error: null });
+    const getPublicUrl = vi
+      .fn()
+      .mockReturnValue({ data: { publicUrl: 'https://supabase.example.com/blog_bucket/test.png' } });
+    (supabase.storage.from as Mock).mockReturnValue({ upload, getPublicUrl });
+    const file = createFile();
+
+    const result = await saveImage(file, 'blogs/temp');
+
+    expect(result).toBe('https://supabase.example.com/blog_bucket/test.png');
+    expect(supabase.storage.from).toHaveBeenCalledWith('blog_bucket');
+    expect(upload).toHaveBeenCalledWith(
+      '1700000000000_test.png',
+      file,
+      { cacheControl: '3600', upsert: false }
+    );
+    expect(mkdir).not.toHaveBeenCalled();
+  });
+
+  it('Supabaseアップロードでエラーが発生した場合、nullを返す', async () => {
+    process.env.NEXT_PUBLIC_USE_SUPABASE_STORAGE = 'true';
+    const upload = vi.fn().mockResolvedValue({ error: { message: 'upload failed' } });
+    const getPublicUrl = vi.fn();
+    (supabase.storage.from as Mock).mockReturnValue({ upload, getPublicUrl });
+    const file = createFile();
+
+    const result = await saveImage(file, 'blogs/temp');
+
+    expect(result).toBeNull();
+    expect(getPublicUrl).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/utils/markdown.test.ts
+++ b/__tests__/utils/markdown.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeMarkdown } from '@/utils/markdown';
+
+describe('normalizeMarkdown', () => {
+  it('シングルクォート3つのコードフェンスをバッククォート3つに変換する', () => {
+    const input = "'''\nconst a = 1;\n'''";
+
+    const result = normalizeMarkdown(input);
+
+    expect(result).toBe('```\nconst a = 1;\n```');
+  });
+
+  it('言語指定付きのシングルクォートコードフェンスを変換する', () => {
+    const input = "'''typescript\nconst a = 1;\n'''";
+
+    const result = normalizeMarkdown(input);
+
+    expect(result).toBe('```typescript\nconst a = 1;\n```');
+  });
+
+  it('全角バッククォート3つを半角バッククォート3つに変換する', () => {
+    const input = '｀｀｀\nconst a = 1;\n｀｀｀';
+
+    const result = normalizeMarkdown(input);
+
+    expect(result).toBe('```\nconst a = 1;\n```');
+  });
+
+  it('言語指定付きの全角バッククォートコードフェンスを変換する', () => {
+    const input = '｀｀｀js\nconst a = 1;\n｀｀｀';
+
+    const result = normalizeMarkdown(input);
+
+    expect(result).toBe('```js\nconst a = 1;\n```');
+  });
+
+  it('複数箇所のコードフェンスをまとめて変換する', () => {
+    const input = "'''js\ncode1\n'''\n\n｀｀｀ts\ncode2\n｀｀｀";
+
+    const result = normalizeMarkdown(input);
+
+    // 閉じフェンス直後の空行は \s* にマッチして詰められる（既存の挙動）
+    expect(result).toBe('```js\ncode1\n```\n```ts\ncode2\n```');
+  });
+
+  it('既に正しいバッククォートのコードフェンスは変更しない', () => {
+    const input = '```js\nconst a = 1;\n```';
+
+    const result = normalizeMarkdown(input);
+
+    expect(result).toBe(input);
+  });
+
+  it('コードフェンス以外の本文は変更しない', () => {
+    const input = '# タイトル\n\n本文テキストです。';
+
+    const result = normalizeMarkdown(input);
+
+    expect(result).toBe(input);
+  });
+
+  it('空文字列を渡した場合は空文字列を返す', () => {
+    const result = normalizeMarkdown('');
+
+    expect(result).toBe('');
+  });
+
+  it('行末に空白があるコードフェンスも変換する', () => {
+    const input = "'''js   \ncode\n'''";
+
+    const result = normalizeMarkdown(input);
+
+    expect(result).toBe('```js\ncode\n```');
+  });
+});


### PR DESCRIPTION
## Summary
- `src/utils/markdown.ts` の `normalizeMarkdown`（純粋関数）に入出力ベースのテストを追加
- `src/utils/image.ts` の `saveImage` / `saveImageToLocal` に `fs/promises` と Supabaseクライアントをモック化したテストを追加（ローカル保存/Supabaseアップロードの分岐、エラー時にnullを返す挙動を検証）

## Test plan
- [x] `npm run lint`(エラー0件、既存warningのみ)
- [x] `npm run test`(93件全てpass、うち新規15件)
- [x] `/code-review medium` を実施(指摘0件)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)