### PR TITLE
#74 blogs/layouts配下の共通コンポーネントにテストを追加

### DIFF
--- a/__tests__/app/components/blogs/BlogFormFields.test.tsx
+++ b/__tests__/app/components/blogs/BlogFormFields.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import BlogFormFields from '@/app/components/blogs/BlogFormFields';
+
+// @vitest-environment jsdom
+
+describe('BlogFormFields', () => {
+  it('defaultTitle/defaultTagが入力欄に表示される', () => {
+    render(<BlogFormFields state={undefined} defaultTitle="初期タイトル" defaultTag="tag1 tag2" />);
+
+    expect((screen.getByLabelText('タイトル') as HTMLInputElement).value).toBe('初期タイトル');
+    expect((screen.getByLabelText('タグ') as HTMLInputElement).value).toBe('tag1 tag2');
+  });
+
+  it('stateのformDataがdefaultTitle/defaultTagより優先される', () => {
+    render(
+      <BlogFormFields
+        state={{ success: false, errors: {}, formData: { title: 'stateタイトル', tag: 'stateタグ' } }}
+        defaultTitle="初期タイトル"
+        defaultTag="tag1"
+      />
+    );
+
+    expect((screen.getByLabelText('タイトル') as HTMLInputElement).value).toBe('stateタイトル');
+    expect((screen.getByLabelText('タグ') as HTMLInputElement).value).toBe('stateタグ');
+  });
+
+  it('タイトルのエラーメッセージが表示される', () => {
+    render(<BlogFormFields state={{ success: false, errors: { title: ['タイトルは必須です。'] } }} />);
+
+    expect(screen.getByText('タイトルは必須です。')).toBeTruthy();
+  });
+
+  it('タグのエラーメッセージが表示される', () => {
+    render(
+      <BlogFormFields
+        state={{ success: false, errors: { tags: ['少なくとも1つのタグを選択してください。'] } }}
+      />
+    );
+
+    expect(screen.getByText('少なくとも1つのタグを選択してください。')).toBeTruthy();
+  });
+
+  it('汎用エラーメッセージが表示される', () => {
+    render(<BlogFormFields state={{ success: false, errors: { error: 'API接続エラー' } }} />);
+
+    expect(screen.getByText('API接続エラー')).toBeTruthy();
+  });
+
+  it('エラーがない場合はエラーメッセージが表示されない', () => {
+    render(<BlogFormFields state={{ success: true, errors: {} }} />);
+
+    expect(screen.queryByText('API接続エラー')).toBeNull();
+  });
+});

--- a/__tests__/app/components/blogs/BlogFormHeader.test.tsx
+++ b/__tests__/app/components/blogs/BlogFormHeader.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import BlogFormHeader from '@/app/components/blogs/BlogFormHeader';
+
+// @vitest-environment jsdom
+
+describe('BlogFormHeader', () => {
+  it('タイトルと説明文が表示される', () => {
+    render(
+      <BlogFormHeader
+        title="記事作成"
+        description="新しい記事を作成します"
+        submitLabel="投稿"
+        pendingLabel="投稿中..."
+        isPending={false}
+        isUploadingImage={false}
+      />
+    );
+
+    expect(screen.getByText('記事作成')).toBeTruthy();
+    expect(screen.getByText('新しい記事を作成します')).toBeTruthy();
+  });
+
+  it('通常時はsubmitLabelを表示し、ボタンは有効になる', () => {
+    render(
+      <BlogFormHeader
+        title="t"
+        description="d"
+        submitLabel="投稿"
+        pendingLabel="投稿中..."
+        isPending={false}
+        isUploadingImage={false}
+      />
+    );
+
+    const button = screen.getByRole('button') as HTMLButtonElement;
+    expect(button.textContent).toBe('投稿');
+    expect(button.disabled).toBe(false);
+  });
+
+  it('isPendingがtrueの場合、pendingLabelを表示しボタンが無効になる', () => {
+    render(
+      <BlogFormHeader
+        title="t"
+        description="d"
+        submitLabel="投稿"
+        pendingLabel="投稿中..."
+        isPending={true}
+        isUploadingImage={false}
+      />
+    );
+
+    const button = screen.getByRole('button') as HTMLButtonElement;
+    expect(button.textContent).toBe('投稿中...');
+    expect(button.disabled).toBe(true);
+  });
+
+  it('isUploadingImageがtrueの場合、ボタンが無効になる', () => {
+    render(
+      <BlogFormHeader
+        title="t"
+        description="d"
+        submitLabel="投稿"
+        pendingLabel="投稿中..."
+        isPending={false}
+        isUploadingImage={true}
+      />
+    );
+
+    const button = screen.getByRole('button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toBe('投稿');
+  });
+});

--- a/__tests__/app/components/blogs/BlogMarkdownEditor.test.tsx
+++ b/__tests__/app/components/blogs/BlogMarkdownEditor.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { createRef } from 'react';
+import BlogMarkdownEditor from '@/app/components/blogs/BlogMarkdownEditor';
+
+// @vitest-environment jsdom
+
+describe('BlogMarkdownEditor', () => {
+  const setup = (overrides: Partial<Parameters<typeof BlogMarkdownEditor>[0]> = {}) => {
+    const setMarkdownState = vi.fn();
+    const setPublicState = vi.fn();
+    const onDrop = vi.fn();
+    const textareaRef = createRef<HTMLTextAreaElement>();
+
+    render(
+      <BlogMarkdownEditor
+        markdownState="本文"
+        setMarkdownState={setMarkdownState}
+        isUploadingImage={false}
+        imageUploadError={null}
+        contextErrors={undefined}
+        onDrop={onDrop}
+        textareaRef={textareaRef}
+        publicState="非公開"
+        setPublicState={setPublicState}
+        {...overrides}
+      />
+    );
+
+    return { setMarkdownState, setPublicState, onDrop };
+  };
+
+  it('markdownStateが本文エリアに表示される', () => {
+    setup();
+
+    expect((screen.getByPlaceholderText('Write a context...') as HTMLTextAreaElement).value).toBe('本文');
+  });
+
+  it('本文を入力するとsetMarkdownStateが呼ばれる', () => {
+    const { setMarkdownState } = setup();
+
+    fireEvent.change(screen.getByPlaceholderText('Write a context...'), { target: { value: '更新後' } });
+
+    expect(setMarkdownState).toHaveBeenCalledWith('更新後');
+  });
+
+  it('isUploadingImageがtrueの場合、アップロード中の表示になる', () => {
+    setup({ isUploadingImage: true });
+
+    expect(screen.getByText('画像アップロード中...')).toBeTruthy();
+  });
+
+  it('imageUploadErrorが表示される', () => {
+    setup({ imageUploadError: '画像のアップロードに失敗しました。' });
+
+    expect(screen.getByText('画像のアップロードに失敗しました。')).toBeTruthy();
+  });
+
+  it('contextErrorsが表示される', () => {
+    setup({ contextErrors: ['本文は必須です。'] });
+
+    expect(screen.getByText('本文は必須です。')).toBeTruthy();
+  });
+
+  it('publicStateが表示される', () => {
+    setup({ publicState: '公開' });
+
+    expect(screen.getByText('公開')).toBeTruthy();
+  });
+
+  it('公開チェックボックスを切り替えるとsetPublicStateが呼ばれる', () => {
+    const { setPublicState } = setup();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(setPublicState).toHaveBeenCalledWith('公開');
+  });
+
+  it('本文エリアにドロップするとonDropが呼ばれる', () => {
+    const { onDrop } = setup();
+
+    fireEvent.drop(screen.getByPlaceholderText('Write a context...'));
+
+    expect(onDrop).toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/components/blogs/BlogMarkdownPreview.test.tsx
+++ b/__tests__/app/components/blogs/BlogMarkdownPreview.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import BlogMarkdownPreview from '@/app/components/blogs/BlogMarkdownPreview';
+
+// @vitest-environment jsdom
+
+describe('BlogMarkdownPreview', () => {
+  it('プレビュー見出しが表示される', () => {
+    render(<BlogMarkdownPreview markdown="" />);
+
+    expect(screen.getByText('プレビュー')).toBeTruthy();
+  });
+
+  it('Markdownの見出しがHTMLに変換されて表示される', () => {
+    render(<BlogMarkdownPreview markdown="# 見出し" />);
+
+    expect(screen.getByRole('heading', { level: 1, name: '見出し' })).toBeTruthy();
+  });
+
+  it('テーブルなどのGFM記法が表示される', () => {
+    render(<BlogMarkdownPreview markdown={'| a | b |\n| --- | --- |\n| 1 | 2 |'} />);
+
+    expect(screen.getByRole('table')).toBeTruthy();
+  });
+});

--- a/__tests__/app/components/layouts/Header.test.tsx
+++ b/__tests__/app/components/layouts/Header.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Header from '@/app/components/layouts/Header';
+import { USER_ROLE } from '@/constants/role';
+
+// @vitest-environment jsdom
+
+type MockSession = {
+  data: { user: { role?: string } } | null;
+};
+
+let mockSession: MockSession;
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => mockSession,
+}));
+
+vi.mock('@/lib/actions/signOut', () => ({
+  customSignOut: vi.fn(),
+}));
+
+describe('Header', () => {
+  beforeEach(() => {
+    mockSession = { data: null };
+  });
+
+  it('未ログイン時はLogin/Sign Upリンクが表示される', () => {
+    render(<Header />);
+
+    expect(screen.getAllByText('Login').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Sign Up').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Sign Out')).toBeNull();
+  });
+
+  it('ログイン時（非管理者）はSign Outが表示され、Post/Tagsは表示されない', () => {
+    mockSession = { data: { user: { role: USER_ROLE.USER } } };
+    render(<Header />);
+
+    expect(screen.getAllByText('Sign Out').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Post')).toBeNull();
+    expect(screen.queryByText('Tags')).toBeNull();
+  });
+
+  it('管理者ログイン時はPost/Tagsリンクが表示される', () => {
+    mockSession = { data: { user: { role: USER_ROLE.ADMIN } } };
+    render(<Header />);
+
+    expect(screen.getAllByText('Post').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Tags').length).toBeGreaterThan(0);
+  });
+
+  it('メニューボタンをクリックするとモバイルナビゲーションが表示される', () => {
+    render(<Header />);
+
+    expect(screen.getAllByText('Home')).toHaveLength(1);
+
+    const menuButton = screen.getByRole('button', { name: 'Open main menu' });
+    expect(menuButton.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(menuButton);
+
+    expect(menuButton.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getAllByText('Home')).toHaveLength(2);
+  });
+});

--- a/__tests__/app/components/layouts/SignOutButton.test.tsx
+++ b/__tests__/app/components/layouts/SignOutButton.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SignOutButton from '@/app/components/layouts/SignOutButton';
+
+// @vitest-environment jsdom
+
+let mockPending = false;
+const mockStartTransition = vi.fn((callback: () => void) => callback());
+const mockCustomSignOut = vi.fn();
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react');
+  return {
+    ...actual,
+    useTransition: () => [mockPending, mockStartTransition],
+  };
+});
+
+vi.mock('@/lib/actions/signOut', () => ({
+  customSignOut: () => mockCustomSignOut(),
+}));
+
+describe('SignOutButton', () => {
+  beforeEach(() => {
+    mockPending = false;
+    mockStartTransition.mockClear();
+    mockCustomSignOut.mockClear();
+  });
+
+  it('通常時は"Sign Out"を表示し、ボタンは有効になる', () => {
+    render(<SignOutButton />);
+
+    const button = screen.getByRole('button') as HTMLButtonElement;
+    expect(button.textContent).toBe('Sign Out');
+    expect(button.disabled).toBe(false);
+  });
+
+  it('クリックするとcustomSignOutが呼ばれる', () => {
+    render(<SignOutButton />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(mockStartTransition).toHaveBeenCalled();
+    expect(mockCustomSignOut).toHaveBeenCalled();
+  });
+
+  it('isPendingがtrueの場合、"Signing out..."を表示しボタンが無効になる', () => {
+    mockPending = true;
+    render(<SignOutButton />);
+
+    const button = screen.getByRole('button') as HTMLButtonElement;
+    expect(button.textContent).toBe('Signing out...');
+    expect(button.disabled).toBe(true);
+  });
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [tsconfigPaths(), react()],
   test: {
     environment: 'jsdom',
+    globals: true,
     env: {
       URL: 'http://localhost:3000',
       NEXT_PUBLIC_SUPABASE_URL: 'https://dummy.supabase.co',


### PR DESCRIPTION
## Summary
- `BlogFormFields` / `BlogFormHeader` / `BlogMarkdownEditor` / `BlogMarkdownPreview` / `Header` / `SignOutButton` のレンダリング内容・イベント発火・分岐ロジックを検証するテストを追加
- `vitest.config.mts` に `globals: true` を追加。未設定だと `@testing-library/react` の afterEach 自動cleanupが効かず、複数テスト間でDOMが残存して重複要素エラーが発生するため修正

Closes #74

## Test plan
- [x] `npm run test` — 全テスト成功（新規28件含む）
- [x] `npm run lint` — 新規/変更ファイルにエラー・警告なし
- [x] `/code-review medium` — 指摘なし