### PR TITLE
#75 ブログ取得系アクション(getBlog/getBlogs/getHomeData)にテストを追加

### DIFF
--- a/__tests__/lib/actions/blogs/getBlog.test.ts
+++ b/__tests__/lib/actions/blogs/getBlog.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getBlog } from '@/lib/actions/blogs/getBlog';
+import type { Mock } from 'vitest';
+import { prisma } from '@/lib/prisma';
+
+vi.mock('next/cache', () => ({
+  unstable_cache: (fn: unknown) => fn,
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    context: { findUnique: vi.fn() },
+  },
+}));
+
+describe('getBlog', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('正常系のテスト', () => {
+    it('該当する記事がある場合、日時をISO文字列に変換して返す', async () => {
+      (prisma.context.findUnique as Mock).mockResolvedValue({
+        id: 1,
+        title: 'タイトル',
+        context: '本文',
+        isPublic: true,
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+        updatedAt: new Date('2024-01-02T00:00:00.000Z'),
+        user: { id: 'user-1', name: 'ユーザー' },
+        tags: [{ name: 'tag1' }],
+      });
+
+      const result = await getBlog(1);
+
+      expect(result).toEqual({
+        id: 1,
+        title: 'タイトル',
+        context: '本文',
+        isPublic: true,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-02T00:00:00.000Z',
+        user: { id: 'user-1', name: 'ユーザー' },
+        tags: [{ name: 'tag1' }],
+      });
+      expect(prisma.context.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 1 } })
+      );
+    });
+  });
+
+  describe('異常系のテスト', () => {
+    it('該当する記事がない場合、nullを返す', async () => {
+      (prisma.context.findUnique as Mock).mockResolvedValue(null);
+
+      const result = await getBlog(999);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/__tests__/lib/actions/blogs/getBlogs.test.ts
+++ b/__tests__/lib/actions/blogs/getBlogs.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getBlogs, PAGE_SIZE } from '@/lib/actions/blogs/getBlogs';
+import type { Mock } from 'vitest';
+import { prisma } from '@/lib/prisma';
+
+vi.mock('next/cache', () => ({
+  unstable_cache: (fn: unknown) => fn,
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    context: { findMany: vi.fn(), count: vi.fn() },
+  },
+}));
+
+describe('getBlogs', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (prisma.context.findMany as Mock).mockResolvedValue([]);
+    (prisma.context.count as Mock).mockResolvedValue(0);
+  });
+
+  describe('正常系のテスト', () => {
+    it('管理者の場合、非公開記事も含めて全件取得する', async () => {
+      await getBlogs({ isAdmin: true, page: 1 });
+
+      expect(prisma.context.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: {} })
+      );
+      expect(prisma.context.count).toHaveBeenCalledWith({ where: {} });
+    });
+
+    it('非管理者の場合、公開記事のみ取得する', async () => {
+      await getBlogs({ isAdmin: false, page: 1 });
+
+      expect(prisma.context.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { isPublic: true } })
+      );
+      expect(prisma.context.count).toHaveBeenCalledWith({ where: { isPublic: true } });
+    });
+
+    it('ページ番号に応じてskipを計算する', async () => {
+      await getBlogs({ isAdmin: true, page: 3 });
+
+      expect(prisma.context.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ take: PAGE_SIZE, skip: (3 - 1) * PAGE_SIZE })
+      );
+    });
+
+    it('取得した記事のcreatedAtをISO文字列に変換して返す', async () => {
+      (prisma.context.findMany as Mock).mockResolvedValue([
+        {
+          id: 1,
+          title: 'タイトル',
+          context: '本文',
+          isPublic: true,
+          createdAt: new Date('2024-01-01T00:00:00.000Z'),
+          user: { name: 'ユーザー' },
+          tags: [{ name: 'tag1', imagePath: null }],
+        },
+      ]);
+      (prisma.context.count as Mock).mockResolvedValue(1);
+
+      const result = await getBlogs({ isAdmin: true, page: 1 });
+
+      expect(result.blogs).toEqual([
+        {
+          id: 1,
+          title: 'タイトル',
+          context: '本文',
+          isPublic: true,
+          createdAt: '2024-01-01T00:00:00.000Z',
+          user: { name: 'ユーザー' },
+          tags: [{ name: 'tag1', imagePath: null }],
+        },
+      ]);
+      expect(result.total).toBe(1);
+      expect(result.totalPages).toBe(1);
+    });
+  });
+
+  describe('異常系のテスト', () => {
+    it('該当する記事が0件の場合、空配列とtotal 0を返す', async () => {
+      const result = await getBlogs({ isAdmin: true, page: 1 });
+
+      expect(result).toEqual({ blogs: [], total: 0, totalPages: 0 });
+    });
+  });
+});

--- a/__tests__/lib/actions/blogs/getHomeData.test.ts
+++ b/__tests__/lib/actions/blogs/getHomeData.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getHomeData } from '@/lib/actions/blogs/getHomeData';
+import type { Mock } from 'vitest';
+
+describe('getHomeData', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    global.fetch = vi.fn();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('正常系のテスト', () => {
+    it('取得したブログ・タグを整形して返す', async () => {
+      const now = new Date();
+      const recentDate = new Date(now);
+      recentDate.setDate(recentDate.getDate() - 1);
+      const oldDate = new Date(now);
+      oldDate.setDate(oldDate.getDate() - 40);
+
+      const blogs = [
+        ...Array.from({ length: 9 }, (_, i) => ({
+          id: i + 1,
+          title: `タイトル${i + 1}`,
+          context: '本文',
+          createdAt: recentDate.toISOString(),
+          user: { name: 'ユーザー' },
+          tags: [],
+        })),
+        {
+          id: 100,
+          title: '古い記事',
+          context: '本文',
+          createdAt: oldDate.toISOString(),
+          user: { name: 'ユーザー' },
+          tags: [],
+        },
+      ];
+      const tags = Array.from({ length: 12 }, (_, i) => ({ id: i + 1, name: `タグ${i + 1}` }));
+
+      (global.fetch as Mock).mockImplementation((url: string) => {
+        if (url.includes('/api/blogs')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(blogs) });
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(tags) });
+      });
+
+      const result = await getHomeData();
+
+      expect(result.latestBlogs).toHaveLength(8);
+      expect(result.tags).toHaveLength(10);
+      expect(result.recentCount).toBe(9);
+    });
+  });
+
+  describe('異常系のテスト', () => {
+    it('URL未設定の場合、空データを返す', async () => {
+      vi.stubEnv('URL', '');
+
+      const result = await getHomeData();
+
+      expect(result).toEqual({ latestBlogs: [], tags: [], recentCount: 0 });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('APIレスポンスが失敗の場合、空データを返す', async () => {
+      (global.fetch as Mock).mockResolvedValue({ ok: false });
+
+      const result = await getHomeData();
+
+      expect(result).toEqual({ latestBlogs: [], tags: [], recentCount: 0 });
+    });
+
+    it('fetchが例外を投げた場合、空データを返す', async () => {
+      (global.fetch as Mock).mockRejectedValue(new Error('Network error'));
+
+      const result = await getHomeData();
+
+      expect(result).toEqual({ latestBlogs: [], tags: [], recentCount: 0 });
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `getBlog` / `getBlogs` / `getHomeData` の正常系・0件時・エラー時の挙動を検証するテストを追加
- `create.test.ts` / `update.test.ts` のモックパターン（`prisma`のモック、`vi.resetAllMocks()`を使った`beforeEach`）を踏襲
- `getBlog`/`getBlogs`は`unstable_cache`でラップされているため、`next/cache`の`unstable_cache`を素通しするモックを追加してテスト可能にした

Closes #75

## Test plan
- [x] `npm run test` — 全テスト成功（新規11件含む）
- [x] `npm run lint` — 新規ファイルにエラー・警告なし
- [x] `/code-review medium` — 指摘なし